### PR TITLE
Fix: suddenly appearing of services section in other urls

### DIFF
--- a/pages/Home/TheHome.vue
+++ b/pages/Home/TheHome.vue
@@ -69,6 +69,9 @@ onMounted(() => {
     x: '-100%',
   }); 
 });
+onUnmounted(()=>{
+  ScrollTrigger.killAll();
+})
 </script>
 
 <template>


### PR DESCRIPTION
Fix: when from the index I clicked on a link from another url and scoll, the services section of the index appeared

![image](https://github.com/lusis-developers/bakano/assets/128764579/0a60d900-cf0f-40d3-a468-e434e4e3cd28)
